### PR TITLE
Fixed NPM Audit issues and added defaultStyle to config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Updating outdated libraries being used, and hopefully adding an option to config.json that will allow you to default to LESS instead of SCSS.
+
 CLI commands for new or existing Angular 2 projects.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Updating outdated libraries being used, and hopefully adding an option to config.json that will allow you to default to LESS instead of SCSS.
-
 CLI commands for new or existing Angular 2 projects.
 
 ## Install
@@ -195,6 +193,7 @@ Same concept applies to all blueprints except the `Component` and `Route` bluepr
 | Options    | |
 |:------------- |:-------|
 | `--scss`     | generate component with .scss file [default] |
+| `--less`     | generate component with .les file |
 | `--css`      | generate component with .css file|
 
 
@@ -212,7 +211,7 @@ Angular CLI Tools generates a lazy loaded route that contains the following file
 
 * lazy-loaded-route.component.ts
 * lazy-loaded-route.component.html
-* lazy-loaded-route.component.scss|css
+* lazy-loaded-route.component.scss|css|less
 * lazy-loaded-route.module.ts
 * lazy-loaded-route.routing.ts
 
@@ -220,6 +219,7 @@ Angular CLI Tools generates a lazy loaded route that contains the following file
 | Options    | |
 |:------------- |:-------|
 | `--scss`     | generate route component with .scss file [default] |
+| `--less`     | generate route component with .less file |
 | `--css`      | generate route component with .css file|
 
 
@@ -227,6 +227,7 @@ Angular CLI Tools generates a lazy loaded route that contains the following file
 |:------------- |:-------|
 | `ngt generate route dashboard`     | generate a lazy loaded 'dashboard' route |
 | `ngt g r dashboard --scss`      | generate component with .scss file|
+| `ngt g r dashboard --less`      | generate component with .less file|
 | `ngt g r dashboard --css`      | generate component with .css file|
 
 To add a new lazy loaded route to your project:
@@ -380,6 +381,16 @@ would give any generated component's selector a prefix of `fancy`
 Both methods do not change the file names, only the `selector` inside the `@Component` constructor of a the `component.ts` file.
 
 **Note:** Using the `--prefix` flag will override whatever is set in the `globalSelectorPrefix` section of your `config.json`
+
+#### Default Style (v.1.10.3)
+
+You can add a defaultStyle option to your custom config.json, to avoid having to add --less or --css to each `generate` command.
+
+```
+{
+    "defaultStyle" : "less"
+}
+```
 
 #### Custom Variables (v.1.10)
 

--- a/bin/commands/generate/blueprint-metadata.js
+++ b/bin/commands/generate/blueprint-metadata.js
@@ -159,7 +159,8 @@ var blueprintMetadataModule = {
 	},
 
 	determineStyleType : function (vFlags) {
-		var styleType = 'scss'; //default
+	    // look inside the user config for a default style of less/css/scss
+		var styleType = userConfigModule.getUserConfig().defaultStyle || 'scss'; //default
 		styleType = tools.isvFlagPresent(vFlags, '--css') ? 'css' : styleType;
 		styleType = tools.isvFlagPresent(vFlags, '--less') ? 'less' : styleType;
 		return styleType;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-cli-tools",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Command Line Interface tools for Angular 2 projects.",
   "main": "index.js",
   "bin": {
@@ -9,8 +9,8 @@
   "dependencies": {
     "async": "^2.0.1",
     "cli-table": "^0.3.1",
-    "download-github-repo": "0.1.3",
-    "find-node-modules": "1.0.3",
+    "download-github-repo": "^0.1.4",
+    "find-node-modules": "^1.0.4",
     "merge": "^1.2.0",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
Our project is using LESS files, and I got tired of adding `--less` to all my generate commands.   I realize I probably could have made new template definitions for everything, but that seemed like a lot of work.

```
{
    "defaultStyle":"less"
}
```
Adding that to your custom `config.json` will change the default from SCSS to LESS or CSS.

Also, I was tired of NPM Audit always warning me about out of date libraries with possible vulnerabilities, so I updated those as well.